### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://highttech.visualstudio.com/f16328a5-7bb7-4521-81ac-41716f278f45/a646a110-3a62-47b0-ab9e-3e9d1eba501c/_apis/work/boardbadge/06da3319-9d00-401d-9f90-375980ff8ed5)](https://highttech.visualstudio.com/f16328a5-7bb7-4521-81ac-41716f278f45/_boards/board/t/a646a110-3a62-47b0-ab9e-3e9d1eba501c/Microsoft.RequirementCategory)
 # test-repo


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://highttech.visualstudio.com/f16328a5-7bb7-4521-81ac-41716f278f45/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.